### PR TITLE
CODA-37 - Fix HTTP headers value extraction

### DIFF
--- a/main.c
+++ b/main.c
@@ -112,14 +112,16 @@ int main(int argc, char const *argv[]) {
     }
 
     char *body;
-    body = strtok(request, ":\n");
-    while (body != NULL) {
-      body = strtok(NULL, ":\n");
-      if (body[0] == 13) {
-        body = strtok(NULL, ":\n");
+    char seps[] = " :\n\r";
+    body = strtok(request, seps);
+
+    while (1) {
+      body = strtok(NULL, seps);
+
+      if (body == NULL) {
         break;
       } else if (strcmp("X-Cear-Auth", body) == 0) {
-        body = strtok(NULL, ":\n\r");
+        body = strtok(NULL, seps);
         if (strcmp(body, getenv("CEAR_KEY")) == 0) {
           isAuthenticated = 1;
         }


### PR DESCRIPTION
**Business justification:** https://trello.com/c/7O4jyATT/37-coda-37-fix-http-headers-value-extraction

**Descritpion:** HTTP headers values were badly extracted. For example `" value"` instead of `"value"` - it was adding heading space sign. That was causing constant "no auth" state for incomming HTTP requests.