### PR TITLE
CODA-38 - Move arguments from POST body to custom header

### DIFF
--- a/main.c
+++ b/main.c
@@ -126,8 +126,11 @@ int main(int argc, char const *argv[]) {
         if (strcmp(body, getenv("CEAR_KEY")) == 0) {
           isAuthenticated = 1;
         }
-      } else if (strcmp("X-Cear-Args", body) == 0) {
-        params = strtok(NULL, seps);
+      } else if (strcmp("X-Cear-Params", body) == 0) {
+        body = strtok(NULL, seps);
+        params = malloc(strlen(body) + 1);
+        memset(params, '\0', strlen(body) + 1);
+        strcpy(params, body);
       }
     }
 
@@ -142,6 +145,7 @@ int main(int argc, char const *argv[]) {
     system(command);
 
     free(command);
+    free(params);
 
     send(clientFd, okReply, strlen(okReply), 0);
     close(clientFd);

--- a/main.c
+++ b/main.c
@@ -112,6 +112,7 @@ int main(int argc, char const *argv[]) {
     }
 
     char *body;
+    char *params;
     char seps[] = " :\n\r";
     body = strtok(request, seps);
 
@@ -125,6 +126,8 @@ int main(int argc, char const *argv[]) {
         if (strcmp(body, getenv("CEAR_KEY")) == 0) {
           isAuthenticated = 1;
         }
+      } else if (strcmp("X-Cear-Args", body) == 0) {
+        params = strtok(NULL, seps);
       }
     }
 
@@ -134,7 +137,7 @@ int main(int argc, char const *argv[]) {
     }
     isAuthenticated = 0;
 
-    char *command = concat(concat(body, " "), cnf);
+    char *command = concat(concat(params, " "), cnf);
     printf("executing command %s\n", command);
     system(command);
 


### PR DESCRIPTION
**Business justification:** https://trello.com/c/3LUzkdFR/38-coda-move-arguments-from-post-body-to-custom-header

**Description:** As a cleaner and easier to maintain solution custom arguments are moved from POST body to a custom header.